### PR TITLE
fix: change `executableName` to fix incorrect execute command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # nenuphar_cli changelog
+## 0.2.2 (2023-09-2)
 
+* fix `executableName` to show correct executable command in help
 ## 0.2.1 (2023-09-19)
 
 * ignoring `/docs/` folder in `.pubignore` file

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -8,7 +8,7 @@ import 'package:nenuphar_cli/src/commands/commands.dart';
 import 'package:nenuphar_cli/src/version.dart';
 import 'package:pub_updater/pub_updater.dart';
 
-const executableName = 'nenuphar_cli';
+const executableName = 'nenuphar';
 const packageName = 'nenuphar_cli';
 const description = 'A Very Good Project created by Very Good CLI.';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nenuphar_cli
 description: An openapi generation CLI for Dart Frog created by Very Good CLI.
-version: 0.2.1
+version: 0.2.2
 homepage: https://piotrfleury.github.io/nenuphar_cli/
 repository: https://github.com/PiotrFLEURY/nenuphar_cli
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
- Hello, I am currently using your package in backend development using `dart_frog` and I noticed a very strange thing: the name of the command to execute in verbose does not match the command to execute, so I created a PR to fix it, it will help developers avoid confusion in using the execution command.
### Before
![Screenshot 2023-09-28 at 01 12 57](https://github.com/PiotrFLEURY/nenuphar_cli/assets/63831488/0ca7e33b-e255-4db2-a79c-20086f8d9372)
### After
![image](https://github.com/PiotrFLEURY/nenuphar_cli/assets/63831488/072ef498-a3a7-4178-a29a-a9e565a31920)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
